### PR TITLE
attrs extensionName,tabName => obj var EXTENSION_NAME, TAB_NAME

### DIFF
--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -12,43 +12,43 @@ import java.util.regex.Pattern;
 import javax.swing.JPanel;
 
 /**
- * Burp Extender to find instances of applications revealing software version numbers 
- * 
- * Some examples: 
+ * Burp Extender to find instances of applications revealing software version numbers
+ *
+ * Some examples:
  * <li>Apache Tomcat/6.0.24 - Error report
  * <li>Server: Apache/2.2.4 (Unix) mod_perl/2.0.3 Perl/v5.8.8
  * <li>X-AspNet-Version: 4.0.30319
- * 
+ *
  * @author August Detlefsen <augustd at codemagi dot com>
  * @contributor Thomas Dosedel <thom at secureideas dot com>
  */
 public class BurpExtender extends PassiveScan {
 
+    public static String TAB_NAME = "Versions";
+    public static String EXTENSION_NAME = "Software Version Checks";
+
     protected RuleTableComponent rulesTable;
     protected BurpSuiteTab mTab;
-    
+
     @Override
     protected void initPassiveScan() {
-	//set the extension Name
-	extensionName = "Software Version Checks";
-        
-        //set the settings namespace 
+        //set the settings namespace
         settingsNamespace = "SVC_";
-	
-	rulesTable = new RuleTableComponent(this, callbacks);
-        
-        mTab = new BurpSuiteTab(extensionName, callbacks);
+
+        rulesTable = new RuleTableComponent(this, callbacks);
+
+        mTab = new BurpSuiteTab(TAB_NAME, callbacks);
         mTab.addComponent(rulesTable);
     }
-    
+
 //    ::TODO:: Add so that settings can save on exit
 //    @Override
 //    public void extensionUnloaded() {
 //        mTab.saveSettings();
 //    }
-    
+
     protected String getIssueName() {
-	return "Software Version Numbers Revealed";
+        return "Software Version Numbers Revealed";
     }
 
     protected String getIssueDetail(List<com.codemagi.burp.ScannerMatch> matches) {
@@ -56,7 +56,7 @@ public class BurpExtender extends PassiveScan {
 	description.append("The server software versions used by the application are revealed by the web server.<br>");
 	description.append("Displaying version information of software information could allow an attacker to determine which vulnerabilities are present in the software, particularly if an outdated software version is in use with published vulnerabilities.<br><br>");
 	description.append("The following software appears to be in use:<br><br>");
-	
+
 	for (ScannerMatch match : matches) {
 	    //add a description
 	    description.append("<li>");
@@ -72,9 +72,9 @@ public class BurpExtender extends PassiveScan {
 	for (ScannerMatch match : matches) {
 	    //if the severity value of the match is higher, then update the stdout value
 	    ScanIssueSeverity matchSeverity = match.getSeverity();
-	    if (matchSeverity != null && 
+	    if (matchSeverity != null &&
 		output.getValue() < matchSeverity.getValue()) {
-		
+
 		output = matchSeverity;
 	    }
 	}
@@ -86,28 +86,28 @@ public class BurpExtender extends PassiveScan {
 	for (ScannerMatch match : matches) {
 	    //if the severity value of the match is higher, then update the stdout value
 	    ScanIssueConfidence matchConfidence = match.getConfidence();
-	    if (matchConfidence != null && 
+	    if (matchConfidence != null &&
 		output.getValue() < matchConfidence.getValue()) {
-		
+
 		output = matchConfidence;
 	    }
 	}
 	return output;
     }
-    
+
     @Override
     protected IScanIssue getScanIssue(IHttpRequestResponse baseRequestResponse, List<ScannerMatch> matches, List<int[]> startStop) {
 	ScanIssueSeverity overallSeverity = getIssueSeverity(matches);
         ScanIssueConfidence overallConfidence = getIssueConfidence(matches);
-        
+
         return new ScanIssue(
-		baseRequestResponse, 
+		baseRequestResponse,
 		helpers,
-		callbacks, 
-		startStop, 
-		getIssueName(), 
-		getIssueDetail(matches), 
-		overallSeverity.getName(), 
+		callbacks,
+		startStop,
+		getIssueName(),
+		getIssueDetail(matches),
+		overallSeverity.getName(),
 		overallConfidence.getName());
     }
 


### PR DESCRIPTION
The extension name shown within Burp suite's tabs `Software Version Reported` is maybe a bit long. It seems that "Target", "Proxy" or "Spider" tabs are 1/3 long in comparison with the Software Version Reported. As a consequence, Burp's tabs panel gets fully bloated when using a small number extensions.

This patch shorts the Software Version Reported tab's name. 

If the full extension name must appear, a solution to keep the show tab name could be to pass the static variable EXTENSION_NAME to `callbacks.issueAlert()`, displaying this way the full extension name in the "Alerts" tab of burp proxy when the extension is loaded. The following excerpt shows an example of this approach:

```java
public class BurpExtender implements IBurpExtender, ... {

    private IBurpExtenderCallbacks callbacks;
    private IExtensionHelpers helpers;

    public static String EXTENSION_NAME = "Software Version Check";
    public static String TAB_NAME = "Versions";   // or Ver. Check,or SoftCheck, or
                                                  // whatever shorter name you prefer
    [...]

    // Implements IBurpExtender 
    @Override
    public void registerExtenderCallbacks(IBurpExtenderCallbacks callbacks) {
        this.callbacks = callbacks;
        helpers = callbacks.getHelpers();
        callbacks.issueAlert(String.format("Loading extension " + EXTENSION_NAME));
        callbacks.setExtensionName(TAB_NAME);

     [...]

    }
```