### PR TITLE
Fixed Tomcat Regex

### DIFF
--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -7,7 +7,7 @@ AOLserver/([\d.]+)	1	AOL web Server	Low	Certain
 Apache/([\d.]+(?: \([ \w]+\))?)	1	Apache	Low	Certain
 Apache-Coyote/([\d.]+)	1	Apache Coyote (Tomcat)	Low	Certain
 >Apache Subversion</a>\s+version\s+([\d.]+(?:\s*\(r\d+\))?)	1	Apache Subversion	Low	Certain
-Apache Tomcat/([\d.]+)	1	Apache Tomcat	Low	Certain
+Apache Tomcat\/([\d.]+)	1	Apache Tomcat	Low	Certain
 ARR/([\d.]+)	1	IIS Application Request Routing	Low	Certain
 ASP\.NET Version:([\d.]+)	1	ASP.Net	Low	Certain
 awselb/([\d.]+)	1	AWS Elastic Load Balancer	Low	Certain


### PR DESCRIPTION
Test case of fixed regex is here: https://regex101.com/r/TfdeSA/1/ The original regex did not work in Burp, and also did not work in the regex tester.

Are there other test cases this regex should have worked for? If so, this change will break those. If not, it's possible a number of these are broken due to unescaped forward slashes.