### PR TITLE
Fixed JBoss Web test case

### DIFF
--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -24,7 +24,7 @@ JBoss-([\d.]+(?:GA)?)	1	JBoss	Low	Certain
 JBoss-EAP/([\d.]+)	1	JBoss Enterprise Application Platform	Low	Certain		https://developers.redhat.com/products/eap/overview/
 JBoss_([\d_]+)	1	JBoss	Low	Certain
 JBPAPP_([\d_]+(?:GA)?)	1	JBoss	Low	Certain
-JBoss(\s)?Web/([\d.]+(?:GA)?)	2	JBoss Webserver	Low	Certain	3
+JBoss(\s)?Web\/([\d.]+(?:GA)?)	2	JBoss Webserver	Low	Certain	3
 Joomla! ([\d.]+)	1	Joomla!	Low	Certain
 JSF/([\d.]+)	1	Java Server Faces	Low	Certain
 JSP/([\d.]+)	1	Generic Java Servlet engine (possibly JBoss)	Low	Certain    


### PR DESCRIPTION
I'm not sure if a comment, a PR, or an issue is best for this, but the recently updated (https://github.com/augustd/burp-suite-software-version-checks/commit/2cf847877c06b5c56fe82629bb7e72a0c5d4cf51) jboss web check is not working for me. The test case are also not working for me in burp, and also not working when tested in a regex tester. 

regex from repo, test cases from repo, not working: https://regex101.com/r/dFJa4h/2
fixed regex from repo, test cases from repo, working: https://regex101.com/r/dFJa4h/1 (escaped forward slash)