### PR TITLE
Roxen CMS version

### DIFF
--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -69,6 +69,7 @@ Perl/v([\d.]+)	1	Perl	Low	Certain
 PHP/([\d.]+(?:[-\w\d\.]+)?)	1	PHP	Low	Certain	2
 Phusion Passenger(?: \([a-zA-Z_/]+\))? ([\d.]+)	1	Phusion Passenger	Low	Certain
 Prototype\s*=\s*\{\s*Version:\s*["']([\d.]+)["']	1	Prototype	Information	Certain
+Roxen CMS(.*[\r\n].*){0,2}version ([\d.]+)	1	Roxen CMS	Low	Certain
 Ruby/([\d.]+(?:/\d{4}-\d{2}-\d{2})?)	1	Ruby	Low	Certain
 Servlet[ /]([\d.]+)	1	Generic Java Servlet engine (possibly JBoss)	Low	Certain
 Sitefinity(\.Resources(,|%2c)( |\+|%20)Version(=|%3d))?\s*([\d.]+)	5	Sitefinity CMS	Low	Certain	3

--- a/src/test/resources/burp/testResponse.txt
+++ b/src/test/resources/burp/testResponse.txt
@@ -78,6 +78,8 @@ X-Powered-By: Phusion Passenger (mod_rails/mod_rack) 3.0.13
 var Prototype = {
 
   Version: '1.7.3',
+<b>Roxen CMS</b> <font color='#ffbe00'>|</font>
+            version 6.1.200 </td>
 Ruby/3.2/2010-11-12
 Servlet 3.0.2.100
 <meta name="Generator" content="Sitefinity 8.0.5700.0 PE" />


### PR DESCRIPTION
Examples: 
* http://archive.is/peKSO
* http://archive.is/bPvn

The text and pipe character don't always have the same styling. I want to make this regex generic, but I also worry that `.*` may be too loose. Any thoughts on this? Maybe just `.{1,200}` or some reasonable numbers?