### PR TITLE
update utils version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <dependency>
             <groupId>com.codemagi</groupId>
             <artifactId>burp-suite-utils</artifactId>
-            <version>1.0.12</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -63,8 +63,8 @@ public class BurpExtender extends PassiveScan implements IHttpListener {
         mTab.addComponent(consolidate);
 
         toolsScope = new ToolsScopeComponent(callbacks);
+        toolsScope.setToolDefault(IBurpExtenderCallbacks.TOOL_PROXY, true);
         toolsScope.setEnabledToolConfig(IBurpExtenderCallbacks.TOOL_PROXY, false);
-        toolsScope.setToolDefault(IBurpExtenderCallbacks.TOOL_PROXY, false);
         toolsScope.setToolDefault(IBurpExtenderCallbacks.TOOL_SCANNER, true);
         toolsScope.setToolDefault(IBurpExtenderCallbacks.TOOL_REPEATER, true);
         toolsScope.setToolDefault(IBurpExtenderCallbacks.TOOL_INTRUDER, true);


### PR DESCRIPTION
Changed isToolSelected() method to return only the selected value of a tool checkbox, regardless of whether the checkbox is enabled in the GUI. Fixes a bug that caused some requests to be inadvertently skipped in the passive scanner. See augustd/burp-suite-utils/pull/30