### PR TITLE
Php false positive

### DIFF
--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -70,7 +70,7 @@ Oracle OpenSSO ([\d.]+.*)	1	Oracle OpenSSO	Low	Certain
 Orion/([\d.]+)	1	Orion	Low	Certain
 NSC/([\d.]+) \(JVM\)	1	Nexpose	Low	Certain
 Perl/v([\d.]+)	1	Perl	Low	Certain
-PHP/(\d\.[\d.]+(?:[-\w\d\.]+)?)	1	PHP	Low	Certain	2
+PHP/([\d]+[\.]+(?:[-\w\d\.]+)?)	1	PHP	Low	Certain	2
 Phusion Passenger(?: \([a-zA-Z_/]+\))? ([\d.]+)	1	Phusion Passenger	Low	Certain
 Prototype\s*=\s*\{\s*Version:\s*["']([\d.]+)["']	1	Prototype	Information	Certain
 RestServices(>|":\s*")([\d.]+)	2	Mendix RestServices	Low	Certain	2

--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -70,7 +70,7 @@ Oracle OpenSSO ([\d.]+.*)	1	Oracle OpenSSO	Low	Certain
 Orion/([\d.]+)	1	Orion	Low	Certain
 NSC/([\d.]+) \(JVM\)	1	Nexpose	Low	Certain
 Perl/v([\d.]+)	1	Perl	Low	Certain
-PHP/([\d.]+(?:[-\w\d\.]+)?)	1	PHP	Low	Certain	2
+PHP/(\d\.[\d.]+(?:[-\w\d\.]+)?)	1	PHP	Low	Certain	2
 Phusion Passenger(?: \([a-zA-Z_/]+\))? ([\d.]+)	1	Phusion Passenger	Low	Certain
 Prototype\s*=\s*\{\s*Version:\s*["']([\d.]+)["']	1	Prototype	Information	Certain
 RestServices(>|":\s*")([\d.]+)	2	Mendix RestServices	Low	Certain	2

--- a/src/test/java/burp/RegexTest.java
+++ b/src/test/java/burp/RegexTest.java
@@ -109,8 +109,7 @@ public class RegexTest {
             
 	    if (foundMatches >= 1) { 
                 matchCount++;
-            } else {
-                System.out.println("Unable to find match for: " + rule.getPattern());
+                System.out.println("Found false positive for: " + rule.getPattern());
             }
         }
         

--- a/src/test/java/burp/RegexTest.java
+++ b/src/test/java/burp/RegexTest.java
@@ -115,7 +115,7 @@ public class RegexTest {
         }
         
         System.out.println(String.format("Found %d matches out of %d", matchCount, matchRules.size()));
-        assertEquals(matchCount, 0);
+        assertEquals(0, matchCount);
     }
 
 	/**

--- a/src/test/resources/burp/falsePositives.txt
+++ b/src/test/resources/burp/falsePositives.txt
@@ -1,2 +1,3 @@
 0t8UGYfJSF/5q6IFb3KImLoQBoA1+3vqfvp61zMUuj3zDV
 85athjhd7yxaclvj3ajdk8l
+ZKbpREiw+wqpzdw+PHP/88M9JjoloS95P7/zVQ1YXWoiuw


### PR DESCRIPTION
Check that PHP version starts with #. This fixes a false positive I encountered. A limitation is that this won't detect PHP version 10, whenever that is released.
