### PR TITLE
Detect Telerik version comments

### DIFF
--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -83,7 +83,7 @@ SOAP::Lite/Perl/([\d.]+)	1	SOAP::Lite	Low	Certain
 spray-can/([\d.]+)	1	Spray	Low	Certain
 squid/([\d.]+)	1	Squid Cache	Low	Certain
 Sun-Java-System-Web-Server/([\d.]+.*)	1	Oracle iPlanet	Low	Certain
-<!-- (201\d\.\d+\.\d+\.\d+) -->	1	Telerik	Low	Firm	2
+<!-- (20\d\d\.\d+\.\d+\.\d+) -->	1	Telerik	Low	Firm	2
 Tomcat-([\d.]+)	1	JBoss (Tomcat)	Low	Certain
 TornadoServer/([\d.]+)	1	Tornado Server	Low	Certain
 Underscore\.js ([\d.]+)	1	Underscore.js	Information	Certain

--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -83,6 +83,7 @@ SOAP::Lite/Perl/([\d.]+)	1	SOAP::Lite	Low	Certain
 spray-can/([\d.]+)	1	Spray	Low	Certain
 squid/([\d.]+)	1	Squid Cache	Low	Certain
 Sun-Java-System-Web-Server/([\d.]+.*)	1	Oracle iPlanet	Low	Certain
+<!-- (201\d\.\d+\.\d+\.\d+) -->	1	Telerik	Low	Firm	2
 Tomcat-([\d.]+)	1	JBoss (Tomcat)	Low	Certain
 TornadoServer/([\d.]+)	1	Tornado Server	Low	Certain
 Underscore\.js ([\d.]+)	1	Underscore.js	Information	Certain

--- a/src/test/resources/burp/testResponse.txt
+++ b/src/test/resources/burp/testResponse.txt
@@ -104,6 +104,8 @@ SOAPServer: SOAP::Lite/Perl/1.20
 Server: spray-can/1.3.3
 Via: 1.0 localhost (squid/3.1.20)
 Sun-Java-System-Web-Server/3.0.2.100
+<!-- 2018.1.117.40 -->   # Telerik
+<!-- 2011.1.315.35 -->   # Telerik
 Tomcat-3.0.2.100
 TornadoServer/3.0.2.100
 Underscore.js 3.0.2.100


### PR DESCRIPTION
Telerik provides a .NET web framework. Sometimes they put the exact version in a HTML comment. It doesn't really specify that it's the Telerik version, so I have put the certainty on "Firm" instead of "Certain".

In the testResponse.txt, the `# Telerik` is a comment and not part of the server response.

Example sites that have this version tag:
* http://hultcenter.org/
* https://sharjah.ae/
* http://clubexpress.com/
* http://realestatestagingassociation.com/
* http://www.vatvalve.com/
* https://www.sophiatem.com/UI/Login.aspx
* http://mipotato.com/
* http://allwrestling.com/
* http://abntcatalogo.com.br/
* http://panin-am.co.id/
* https://www.nash-gorod.kz/
* http://www.gooutdoors.co.uk/
* https://iranhost.com/
* http://uel.edu.vn/
* http://itm.co.ir/
* https://www.hdbank.com.vn/
* http://hcmute.edu.vn/