### PR TITLE
Improve version check for BOA web server

### DIFF
--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -12,7 +12,7 @@ ARR/([\d.]+)	1	IIS Application Request Routing	Low	Certain
 Artifactory/([\d.]+)	1	Artifactory	Low	Certain	2
 ASP\.NET Version:([\d.]+)	1	ASP.Net	Low	Firm
 awselb/([\d.]+)	1	AWS Elastic Load Balancer	Low	Certain
-B[oO][aA]/(\d[\d.rc]+)	1	BOA Web Server	Low	Certain	2
+((?i)Boa)/(\d+\.[\d.rc]+)	1	BOA Web Server	Low	Certain	2
 CKEDITOR.*version:"([\d.]+)"	1	CKEditor	Information	Certain
 Communique/([\d.-]+)	1	Adobe Communique	Low	Certain
 Ember\.VERSION\s*=\s*["']([\w.]+)["']	1	Ember	Information	Certain	2

--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -12,7 +12,7 @@ ARR/([\d.]+)	1	IIS Application Request Routing	Low	Certain
 Artifactory/([\d.]+)	1	Artifactory	Low	Certain	2
 ASP\.NET Version:([\d.]+)	1	ASP.Net	Low	Firm
 awselb/([\d.]+)	1	AWS Elastic Load Balancer	Low	Certain
-BOA/([\d.]+)	1	BOA Web Server	Low	Certain
+B[oO][aA]/(\d[\d.rc]+)	1	BOA Web Server	Low	Certain	2
 CKEDITOR.*version:"([\d.]+)"	1	CKEditor	Information	Certain
 Communique/([\d.-]+)	1	Adobe Communique	Low	Certain
 Ember\.VERSION\s*=\s*["']([\w.]+)["']	1	Ember	Information	Certain	2

--- a/src/test/resources/burp/falsePositives.txt
+++ b/src/test/resources/burp/falsePositives.txt
@@ -2,3 +2,4 @@
 85athjhd7yxaclvj3ajdk8l
 ZKbpREiw+wqpzdw+PHP/88M9JjoloS95P7/zVQ1YXWoiuw
 "clientId":"6zhazcojdkxq15q4x0azoy04f73"
+dfSbIPX0fBOA/6UfConhSSg

--- a/src/test/resources/burp/testResponse.txt
+++ b/src/test/resources/burp/testResponse.txt
@@ -13,7 +13,7 @@ Server:Artifactory/5.4.6
 <hr/><address style="font-size:small;">Artifactory/5.4.6 Server at my.internal.tld.net/(null) Port 80</address></body></html>
 ASP.NET Version:3.0.2.100
 Server: awselb/2.0
-BOA/3.0.2.100
+BOA/345.0.2.100
 Server: Boa/0.94.14rc21
 CKEDITOR=function(){var a=/(^|.*[\\\/])ckeditor\.js(?:\?.*|;.*)?$/i,d={timestamp:"G14E",version:"4.5.7"
 Communique/4.2.0-20160330

--- a/src/test/resources/burp/testResponse.txt
+++ b/src/test/resources/burp/testResponse.txt
@@ -14,6 +14,7 @@ Server:Artifactory/5.4.6
 ASP.NET Version:3.0.2.100
 Server: awselb/2.0
 BOA/3.0.2.100
+Server: Boa/0.94.14rc21
 CKEDITOR=function(){var a=/(^|.*[\\\/])ckeditor\.js(?:\?.*|;.*)?$/i,d={timestamp:"G14E",version:"4.5.7"
 Communique/4.2.0-20160330
 Ember.VERSION = '1.0.pre';


### PR DESCRIPTION
Match partial case insensitive.  HTTP response headers often capitalize this as
"Boa" instead of "BOA". E.g.

    Server: Boa/0.94.14rc21

Also, I got a false positive in base64-encoded data, so make sure we have at
least one number after "Boa/".