### PR TITLE
Fix False positive on Linux version

### DIFF
--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -42,7 +42,7 @@ jquery[/-]([\d-.]+)	1	jQuery	Information	Certain	2
 jQuery v([\d.]+)	1	jQuery	Information	Certain
 Liferay Portal Enterprise Edition ([\d.]+)	1	Liferay Portal	Low	Certain
 lighttpd/([\d.]+)	1	lighttpd	Low	Certain
-Linux ([a-z0-9\.\-_]+)	1	Linux	Low	Certain
+Linux (\d.[a-z0-9\.\-_]+)	1	Linux	Low	Certain
 LiteSpeed/([\d.]+)	1	OpenCms	Low	Certain
 Microsoft-HTTPAPI/([\d.]+)	1	Microsoft HTTPAPI	Low	Certain
 Microsoft-IIS/([\d.]+)	1	Microsoft IIS	Low	Certain

--- a/src/test/resources/burp/falsePositives.txt
+++ b/src/test/resources/burp/falsePositives.txt
@@ -2,3 +2,4 @@
 85athjhd7yxaclvj3ajdk8l
 ZKbpREiw+wqpzdw+PHP/88M9JjoloS95P7/zVQ1YXWoiuw
 "clientId":"6zhazcojdkxq15q4x0azoy04f73"
+The IcedTea browser plugin installed on Linux is incompatible with


### PR DESCRIPTION
Require first character to be a digit. See #76